### PR TITLE
fix font fallback

### DIFF
--- a/posts/2020-10-02-demystifying-interpreters/demos/Lexer.js
+++ b/posts/2020-10-02-demystifying-interpreters/demos/Lexer.js
@@ -9,7 +9,7 @@ const lexerClass = css`
   background: black;
   color: white;
   margin: 2em auto;
-  font-family: "Roboto", "sans-serif";
+  font-family: "Roboto", sans-serif;
 
   & .input {
     height: 40px;
@@ -186,7 +186,7 @@ const lexerClass = css`
 
     & ul li pre {
       margin: 0;
-      font-family: "Roboto", "sans-serif";
+      font-family: "Roboto", sans-serif;
       display: inline-block;
 
       &.mono {


### PR DESCRIPTION
**nitpick**: [Generic family names are keywords and must not be quoted](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E)

|`before`|`after`|
|:---:|:---:|
| ![screenshot showing times new roman](https://user-images.githubusercontent.com/8649362/94982436-4c355780-0532-11eb-9926-55f1e5c405e1.png) | ![screenshot showing sans-serif font](https://user-images.githubusercontent.com/8649362/94982439-50617500-0532-11eb-8aca-87b540d6af2a.png) |


I wanted to say "Amazing blog post", but I feel this October open-source contributions have been cursed.
Really good content! 😄 